### PR TITLE
feat: extra placeholders

### DIFF
--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
@@ -509,7 +509,8 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
             return;
         }
 
-        if (getDisplayType().category().getSource() != EDisplayTypeDataSource.TRAIN_INFORMATION) {
+        EDisplayTypeDataSource source = getDisplayType().category().getSource();
+        if (source != EDisplayTypeDataSource.TRAIN_INFORMATION && source != EDisplayTypeDataSource.NONE) {
             return;
         }
 

--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
@@ -109,7 +109,7 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
     // CLIENT DISPLAY ONLY - this data is not saved!
     public boolean assembledOnContraption = false;
     private long lastRefreshedTime;
-    private TrainDisplayData trainData = TrainDisplayData.empty();
+    private TrainDisplayData trainData = TrainDisplayData.empty(0);
     private CarriageData carriageData = new CarriageData(0, Direction.NORTH, false);
     
     // OTHER
@@ -520,8 +520,14 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
         if (level.isClientSide && syncTicks <= 0) {
             syncTicks = ModClientConfig.DISPLAY_REFRESH_RATE.get();
 
-            ModNetworkManager.GET_TRAIN_DISPLAY_DATA.send(NetworkDirection.toServer(), new GetTrainDisplayDataPacketData.Request(((CarriageContraptionEntity)carriage.entity).trainId), (response) -> {
+            if (!(carriage.entity instanceof CarriageContraptionEntity carriageContraption)) {
+                return;
+            }
+
+            ModNetworkManager.GET_TRAIN_DISPLAY_DATA.send(NetworkDirection.toServer(), new GetTrainDisplayDataPacketData.Request(carriageContraption.trainId), (response) -> {
                 TrainDisplayData data = response.getData();
+                int carriagesCount = TrainUtils.getTrain(carriageContraption.trainId).map(x -> x.carriages.size()).orElse(0);
+                this.trainData = TrainDisplayData.empty(carriagesCount);
                 if (data.getState().isOutOfService() && this.trainData.getState().isOutOfService()) {
                     return;
                 }
@@ -542,8 +548,8 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
                 if (outOfService) {
                     shouldUpdate = true;
                 }
-                this.trainData = outOfService ? TrainDisplayData.empty() : data;
-                this.carriageData = new CarriageData(((CarriageContraptionEntity)carriage.entity).carriageIndex, carriage.getAssemblyDirection(), data.isOppositeDirection());
+                this.trainData = outOfService ? TrainDisplayData.empty(carriagesCount) : data;
+                this.carriageData = new CarriageData(carriageContraption.carriageIndex, carriage.getAssemblyDirection(), data.isOppositeDirection());
                 this.relativeExitDirection.clear();
                 
                 getRenderer().update(level, pos, state, this, shouldUpdate ? EUpdateReason.LAYOUT_CHANGED : EUpdateReason.DATA_CHANGED);

--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
@@ -107,6 +107,7 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
     private IDisplaySettings displayTypeSettings = AdvancedDisplaysRegistry.createSettings(ModDisplayTypes.TRAIN_DESTINATION_SIMPLE);
     
     // CLIENT DISPLAY ONLY - this data is not saved!
+    public boolean assembledOnContraption = false;
     private long lastRefreshedTime;
     private TrainDisplayData trainData = TrainDisplayData.empty();
     private CarriageData carriageData = new CarriageData(0, Direction.NORTH, false);
@@ -503,6 +504,7 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
 
     @Override
     public void contraptionTick(Level level, BlockPos pos, BlockState state, CarriageContraption carriage) {
+        assembledOnContraption = true;
         getRenderer().tick(level, pos, state, this);
 
         if (!isController()) {

--- a/common/src/main/java/de/mrjulsen/crn/client/ber/variants/BERRichText.java
+++ b/common/src/main/java/de/mrjulsen/crn/client/ber/variants/BERRichText.java
@@ -28,7 +28,7 @@ public class BERRichText implements AbstractAdvancedDisplayRenderer<StaticTextDi
     public void tick(Level level, BlockPos pos, BlockState state, AdvancedDisplayBlockEntity blockEntity, AdvancedDisplayRenderInstance parent) {
         for (int i = 0; i < labels.length && i < getDisplaySettings(blockEntity).getComponents().size(); i++) {
             TextComponent component = getDisplaySettings(blockEntity).getComponents().get(i);
-            MutableComponent text = getText(component.getStaticText());    
+            MutableComponent text = getText(component.getStaticText(), blockEntity);
             labels[i].text.set(text);
         }
     }
@@ -40,8 +40,8 @@ public class BERRichText implements AbstractAdvancedDisplayRenderer<StaticTextDi
         }
     }
 
-    private MutableComponent getText(String input) {
-        String staticText = VariableManager.replacePlaceholders(input);
+    private MutableComponent getText(String input, AdvancedDisplayBlockEntity blockEntity) {
+        String staticText = VariableManager.replacePlaceholders(input, blockEntity);
         MutableComponent text = TextUtils.empty();
         if (staticText != null) {
             try {
@@ -71,7 +71,7 @@ public class BERRichText implements AbstractAdvancedDisplayRenderer<StaticTextDi
             TextComponent component = components.get(i);
             BERLabel label = new BERLabel();
 
-            MutableComponent text = getText(component.getStaticText());
+            MutableComponent text = getText(component.getStaticText(), blockEntity);
 
             label.clippingArea.set(Rectangle.withSize(3, 3, blockEntity.getXSizeScaled() * 16 - 6, blockEntity.getYSizeScaled() * 16 - 6));
             label.horizontalScrollingSpeed.set(SCROLLING_SPEED);

--- a/common/src/main/java/de/mrjulsen/crn/client/ber/variants/BERStaticText.java
+++ b/common/src/main/java/de/mrjulsen/crn/client/ber/variants/BERStaticText.java
@@ -35,7 +35,7 @@ public class BERStaticText implements AbstractAdvancedDisplayRenderer<SimpleStat
 
     @Override
     public void tick(Level level, BlockPos pos, BlockState state, AdvancedDisplayBlockEntity blockEntity, AdvancedDisplayRenderInstance parent) {
-        MutableComponent text = getText(getDisplaySettings(blockEntity).getStaticText());    
+        MutableComponent text = getText(getDisplaySettings(blockEntity).getStaticText(), blockEntity);
         label.text.set(text);
     }
     
@@ -44,8 +44,8 @@ public class BERStaticText implements AbstractAdvancedDisplayRenderer<SimpleStat
         label.render(graphics, light);
     }
 
-    private MutableComponent getText(String input) {
-        String staticText = VariableManager.replacePlaceholders(input);
+    private MutableComponent getText(String input, AdvancedDisplayBlockEntity blockEntity) {
+        String staticText = VariableManager.replacePlaceholders(input, blockEntity);
         MutableComponent text = TextUtils.empty();
         if (staticText != null) {
             try {

--- a/common/src/main/java/de/mrjulsen/crn/data/train/ClientTrainStop.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/ClientTrainStop.java
@@ -40,12 +40,12 @@ public class ClientTrainStop extends TrainStop implements ITrainListenerClient<C
             String scheduleTitle, boolean isCustomTitle, String terminusText, int stayDuration, boolean simulated,
             long scheduledDepartureTime, long scheduledArrivalTime, int cycle, ClientStationTag tag, long realTimeArrivalTime,
             long realTimeDepartureTime, int realTimeCycle, ClientStationTag realTimeTag,
-             int realTimeTicksUntilArrival, TrainState trainPosition, int trainCarriages)
+             int realTimeTicksUntilArrival, TrainState trainPosition)
     {
         super(scheduleIndex, sectionIndex, trainId, trainName, trainIcon, trainInfo, scheduleTitle, isCustomTitle,
                 terminusText, stayDuration, simulated, scheduledDepartureTime, scheduledArrivalTime, cycle, tag,
                 realTimeArrivalTime, realTimeDepartureTime, realTimeCycle, realTimeTag,
-                realTimeTicksUntilArrival, trainPosition, trainCarriages);
+                realTimeTicksUntilArrival, trainPosition);
         initEvents();
     }
 
@@ -152,8 +152,7 @@ public class ClientTrainStop extends TrainStop implements ITrainListenerClient<C
             nbt.getInt(NBT_REAL_CYCLE),
             ClientStationTag.fromNbt(nbt.getCompound(NBT_REAL_TIME_TAG)),
             0,
-            TrainState.BEFORE,
-            nbt.getInt(NBT_TRAIN_CARRIAGES)
+            TrainState.BEFORE
         );
     }
 

--- a/common/src/main/java/de/mrjulsen/crn/data/train/ClientTrainStop.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/ClientTrainStop.java
@@ -40,12 +40,12 @@ public class ClientTrainStop extends TrainStop implements ITrainListenerClient<C
             String scheduleTitle, boolean isCustomTitle, String terminusText, int stayDuration, boolean simulated,
             long scheduledDepartureTime, long scheduledArrivalTime, int cycle, ClientStationTag tag, long realTimeArrivalTime,
             long realTimeDepartureTime, int realTimeCycle, ClientStationTag realTimeTag,
-             int realTimeTicksUntilArrival, TrainState trainPosition)
+             int realTimeTicksUntilArrival, TrainState trainPosition, int trainCarriages)
     {
         super(scheduleIndex, sectionIndex, trainId, trainName, trainIcon, trainInfo, scheduleTitle, isCustomTitle,
                 terminusText, stayDuration, simulated, scheduledDepartureTime, scheduledArrivalTime, cycle, tag,
                 realTimeArrivalTime, realTimeDepartureTime, realTimeCycle, realTimeTag,
-                realTimeTicksUntilArrival, trainPosition);
+                realTimeTicksUntilArrival, trainPosition, trainCarriages);
         initEvents();
     }
 
@@ -152,7 +152,8 @@ public class ClientTrainStop extends TrainStop implements ITrainListenerClient<C
             nbt.getInt(NBT_REAL_CYCLE),
             ClientStationTag.fromNbt(nbt.getCompound(NBT_REAL_TIME_TAG)),
             0,
-            TrainState.BEFORE
+            TrainState.BEFORE,
+            nbt.getInt(NBT_TRAIN_CARRIAGES)
         );
     }
 

--- a/common/src/main/java/de/mrjulsen/crn/data/train/TrainStop.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/TrainStop.java
@@ -59,7 +59,6 @@ public class TrainStop implements Comparable<TrainStop> {
     protected final String terminusText;
     protected final int stayDuration;
     protected final boolean isCustomTitle;
-    protected final int trainCarriages;
 
     protected boolean simulated;
     protected long simulationTime;
@@ -85,7 +84,7 @@ public class TrainStop implements Comparable<TrainStop> {
             String scheduleTitle, boolean isCustomTitle, String terminusText, int stayDuration, boolean simulated,
             long scheduledDepartureTime, long scheduledArrivalTime, int cycle, ClientStationTag tag, long realTimeArrivalTime,
             long realTimeDepartureTime, int realTimeCycle, ClientStationTag realTimeTag,
-            int realTimeTicksUntilArrival, TrainState trainPosition, int trainCarriages) {
+            int realTimeTicksUntilArrival, TrainState trainPosition) {
         this.scheduleIndex = scheduleIndex;
         this.sectionIndex = sectionIndex;
         this.trainId = trainId;
@@ -107,7 +106,6 @@ public class TrainStop implements Comparable<TrainStop> {
         this.realTimeTag = realTimeTag;
         this.realTimeTicksUntilArrival = realTimeTicksUntilArrival;
         this.trainState = trainPosition;
-        this.trainCarriages = trainCarriages;
     }
 
     public TrainStop(TrainPrediction prediction) {
@@ -136,8 +134,7 @@ public class TrainStop implements Comparable<TrainStop> {
             prediction.getCurrentCycle() - (lastCycle ? 1 : 0), 
             GlobalSettings.getInstance().getOrCreateStationTagFor(prediction.getRealTimeStationName()).getClientTag(prediction.getRealTimeStationName()),
             (int)prediction.realTime().arrivalIn(), 
-            TrainState.BEFORE,
-            prediction.getData().getTrain().carriages.size()
+            TrainState.BEFORE
         );
         //updateRealTime(prediction);
     }
@@ -164,8 +161,7 @@ public class TrainStop implements Comparable<TrainStop> {
             this.realTimeCycle,
             this.realTimeTag,
             this.realTimeTicksUntilArrival,
-            this.trainState,
-            this.trainCarriages
+            this.trainState
         );
     }
 
@@ -398,10 +394,6 @@ public class TrainStop implements Comparable<TrainStop> {
         return trainState == TrainState.AFTER;
     }
 
-    public int getTrainCarriages() {
-        return trainCarriages;
-    }
-
     @Override
     public int compareTo(TrainStop o) {
         return Long.compare(getScheduledArrivalTime(), o.getScheduledArrivalTime());
@@ -428,7 +420,6 @@ public class TrainStop implements Comparable<TrainStop> {
         nbt.putLong(NBT_REAL_TIME_DEPARTURE_TIME, realTimeDepartureTime);
         nbt.putInt(NBT_REAL_CYCLE, realTimeCycle);
         nbt.put(NBT_REAL_TIME_TAG, realTimeTag.toNbt());
-        nbt.putInt(NBT_TRAIN_CARRIAGES, trainCarriages);
         return nbt;
     }
 
@@ -454,8 +445,7 @@ public class TrainStop implements Comparable<TrainStop> {
             nbt.getInt(NBT_REAL_CYCLE),
             ClientStationTag.fromNbt(nbt.getCompound(NBT_REAL_TIME_TAG)),
             0,
-            TrainState.BEFORE,
-            nbt.getInt(NBT_TRAIN_CARRIAGES)
+            TrainState.BEFORE
         );
     }
 }

--- a/common/src/main/java/de/mrjulsen/crn/data/train/TrainStop.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/TrainStop.java
@@ -36,6 +36,7 @@ public class TrainStop implements Comparable<TrainStop> {
     protected static final String NBT_STAY_DURATION = "StayDuration";
     protected static final String NBT_IS_CUSTOM_TITLE = "IsCustomTitle";
     protected static final String NBT_SIMULATED_TIME = "SimulationTime";
+    protected static final String NBT_TRAIN_CARRIAGES = "TrainCarriages";
 
     protected static final String NBT_SCHEDULED_DEPARTURE_TIME = "ScheduledDeparture";
     protected static final String NBT_SCHEDULED_ARRIVAL_TIME = "ScheduledArrival";
@@ -58,6 +59,7 @@ public class TrainStop implements Comparable<TrainStop> {
     protected final String terminusText;
     protected final int stayDuration;
     protected final boolean isCustomTitle;
+    protected final int trainCarriages;
 
     protected boolean simulated;
     protected long simulationTime;
@@ -83,7 +85,7 @@ public class TrainStop implements Comparable<TrainStop> {
             String scheduleTitle, boolean isCustomTitle, String terminusText, int stayDuration, boolean simulated,
             long scheduledDepartureTime, long scheduledArrivalTime, int cycle, ClientStationTag tag, long realTimeArrivalTime,
             long realTimeDepartureTime, int realTimeCycle, ClientStationTag realTimeTag,
-            int realTimeTicksUntilArrival, TrainState trainPosition) {
+            int realTimeTicksUntilArrival, TrainState trainPosition, int trainCarriages) {
         this.scheduleIndex = scheduleIndex;
         this.sectionIndex = sectionIndex;
         this.trainId = trainId;
@@ -105,6 +107,7 @@ public class TrainStop implements Comparable<TrainStop> {
         this.realTimeTag = realTimeTag;
         this.realTimeTicksUntilArrival = realTimeTicksUntilArrival;
         this.trainState = trainPosition;
+        this.trainCarriages = trainCarriages;
     }
 
     public TrainStop(TrainPrediction prediction) {
@@ -133,7 +136,8 @@ public class TrainStop implements Comparable<TrainStop> {
             prediction.getCurrentCycle() - (lastCycle ? 1 : 0), 
             GlobalSettings.getInstance().getOrCreateStationTagFor(prediction.getRealTimeStationName()).getClientTag(prediction.getRealTimeStationName()),
             (int)prediction.realTime().arrivalIn(), 
-            TrainState.BEFORE
+            TrainState.BEFORE,
+            prediction.getData().getTrain().carriages.size()
         );
         //updateRealTime(prediction);
     }
@@ -160,7 +164,8 @@ public class TrainStop implements Comparable<TrainStop> {
             this.realTimeCycle,
             this.realTimeTag,
             this.realTimeTicksUntilArrival,
-            this.trainState
+            this.trainState,
+            this.trainCarriages
         );
     }
 
@@ -393,6 +398,10 @@ public class TrainStop implements Comparable<TrainStop> {
         return trainState == TrainState.AFTER;
     }
 
+    public int getTrainCarriages() {
+        return trainCarriages;
+    }
+
     @Override
     public int compareTo(TrainStop o) {
         return Long.compare(getScheduledArrivalTime(), o.getScheduledArrivalTime());
@@ -419,6 +428,7 @@ public class TrainStop implements Comparable<TrainStop> {
         nbt.putLong(NBT_REAL_TIME_DEPARTURE_TIME, realTimeDepartureTime);
         nbt.putInt(NBT_REAL_CYCLE, realTimeCycle);
         nbt.put(NBT_REAL_TIME_TAG, realTimeTag.toNbt());
+        nbt.putInt(NBT_TRAIN_CARRIAGES, trainCarriages);
         return nbt;
     }
 
@@ -444,7 +454,8 @@ public class TrainStop implements Comparable<TrainStop> {
             nbt.getInt(NBT_REAL_CYCLE),
             ClientStationTag.fromNbt(nbt.getCompound(NBT_REAL_TIME_TAG)),
             0,
-            TrainState.BEFORE
+            TrainState.BEFORE,
+            nbt.getInt(NBT_TRAIN_CARRIAGES)
         );
     }
 }

--- a/common/src/main/java/de/mrjulsen/crn/data/train/portable/BasicTrainDisplayData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/portable/BasicTrainDisplayData.java
@@ -2,7 +2,6 @@ package de.mrjulsen.crn.data.train.portable;
 
 import java.util.*;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.content.trains.entity.TrainIconType;
 
@@ -19,7 +18,6 @@ import de.mrjulsen.crn.data.train.TrainListener;
 import de.mrjulsen.crn.data.train.TrainStop;
 import de.mrjulsen.crn.data.train.TrainStatus.CompiledTrainStatus;
 import de.mrjulsen.crn.event.ModCommonEvents;
-import de.mrjulsen.mcdragonlib.util.NbtUtils;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -62,6 +60,7 @@ public class BasicTrainDisplayData {
     private final Collection<ResourceLocation> statusLocations; // Server
     private final boolean cancelled;
     private final Map<ETrainStopState, StateData> dataByState;
+    private final int carriages;
 
     private final Cache<List<CompiledTrainStatus>> clientStatus;
     private static final Cache<Map<ETrainStopState, StateData>> fallbackStateData = new Cache<>(() -> {
@@ -77,13 +76,15 @@ public class BasicTrainDisplayData {
     private static final String NBT_STATUS = "Status";
     private static final String NBT_CANCELLED = "Cancelled";
     private static final String NBT_STATE_DATA = "StateData";
+    private static final String NBT_CARRIAGES = "Carriages";
 
     private BasicTrainDisplayData(
         UUID id,
         TrainIconType icon,
         Collection<ResourceLocation> statusLocations,
         boolean cancelled,
-        Map<ETrainStopState, StateData> dataByState
+        Map<ETrainStopState, StateData> dataByState,
+        int carriages
     ) {
         Objects.requireNonNull(id, "id cannot be null");
         Objects.requireNonNull(icon, "icon cannot be null");
@@ -94,12 +95,13 @@ public class BasicTrainDisplayData {
         this.statusLocations = statusLocations;
         this.cancelled = cancelled;
         this.dataByState = dataByState;
+        this.carriages = carriages;
 
         this.clientStatus = new Cache<>(() -> CompiledTrainStatus.load(statusLocations));
     }
 
     public static BasicTrainDisplayData empty() {
-        return new BasicTrainDisplayData(new UUID(0, 0), /*"", DLColor.TRANSPARENT, */TrainIconType.getDefault(), List.of(), true, fallbackStateData.get());
+        return new BasicTrainDisplayData(new UUID(0, 0), /*"", DLColor.TRANSPARENT, */TrainIconType.getDefault(), List.of(), true, fallbackStateData.get(), 0);
     }
 
     /** Server-side only! */
@@ -138,7 +140,8 @@ public class BasicTrainDisplayData {
                     data.getTrain().icon,
                     new ArrayList<>(data.getStatus()),
                     data.isCancelled(),
-                    dataByState
+                    dataByState,
+                    data.getTrain().carriages.size()
             );
         }).orElse(empty());
     }
@@ -180,7 +183,8 @@ public class BasicTrainDisplayData {
                 stop.getTrainIcon(),
                 new ArrayList<>(data.getStatus()),
                 data.isCancelled(),
-                dataByState
+                dataByState,
+                stop.getTrainCarriages()
             );
         }).orElse(empty());
     }
@@ -217,6 +221,10 @@ public class BasicTrainDisplayData {
         return !getStatus().isEmpty();
     }
 
+    public int getCarriages() {
+        return carriages;
+    }
+
     public CompoundTag toNbt() {
         CompoundTag nbt = new CompoundTag();
 
@@ -230,6 +238,7 @@ public class BasicTrainDisplayData {
         nbt.put(NBT_STATUS, statusList);
         nbt.putBoolean(NBT_CANCELLED, cancelled);
         ModUtils.putMap(nbt, NBT_STATE_DATA, dataByState, (k) -> String.valueOf(k.getId()), StateData::toNbt);
+        nbt.putInt(NBT_CARRIAGES, carriages);
 
         return nbt;
     }
@@ -240,7 +249,8 @@ public class BasicTrainDisplayData {
             TrainIconType.byId(new ResourceLocation(nbt.getString(NBT_ICON))),
             nbt.getList(NBT_STATUS, Tag.TAG_STRING).stream().map(x -> new ResourceLocation(((StringTag)x).getAsString())).toList(),
             nbt.getBoolean(NBT_CANCELLED),
-            nbt.contains(NBT_STATE_DATA) ? ModUtils.getMap(nbt, NBT_STATE_DATA, (k) -> ETrainStopState.getById(Integer.parseInt(k)), StateData::fromNbt) : fallbackStateData.get()
+            nbt.contains(NBT_STATE_DATA) ? ModUtils.getMap(nbt, NBT_STATE_DATA, (k) -> ETrainStopState.getById(Integer.parseInt(k)), StateData::fromNbt) : fallbackStateData.get(),
+            nbt.getInt(NBT_CARRIAGES)
         );
     }
 

--- a/common/src/main/java/de/mrjulsen/crn/data/train/portable/BasicTrainDisplayData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/portable/BasicTrainDisplayData.java
@@ -8,14 +8,11 @@ import com.simibubi.create.content.trains.entity.TrainIconType;
 import de.mrjulsen.crn.Constants;
 import de.mrjulsen.crn.data.TrainCategory;
 import de.mrjulsen.crn.data.TrainLine;
-import de.mrjulsen.crn.data.train.ETrainStopState;
-import de.mrjulsen.crn.data.train.ScheduleSection;
+import de.mrjulsen.crn.data.train.*;
 import de.mrjulsen.crn.exceptions.RuntimeSideException;
 import de.mrjulsen.crn.util.ModUtils;
 import de.mrjulsen.mcdragonlib.util.Cache;
 import de.mrjulsen.mcdragonlib.util.DLColor;
-import de.mrjulsen.crn.data.train.TrainListener;
-import de.mrjulsen.crn.data.train.TrainStop;
 import de.mrjulsen.crn.data.train.TrainStatus.CompiledTrainStatus;
 import de.mrjulsen.crn.event.ModCommonEvents;
 import net.minecraft.nbt.CompoundTag;
@@ -100,8 +97,8 @@ public class BasicTrainDisplayData {
         this.clientStatus = new Cache<>(() -> CompiledTrainStatus.load(statusLocations));
     }
 
-    public static BasicTrainDisplayData empty() {
-        return new BasicTrainDisplayData(new UUID(0, 0), /*"", DLColor.TRANSPARENT, */TrainIconType.getDefault(), List.of(), true, fallbackStateData.get(), 0);
+    public static BasicTrainDisplayData empty(int carriages) {
+        return new BasicTrainDisplayData(new UUID(0, 0), TrainIconType.getDefault(), List.of(), true, fallbackStateData.get(), carriages);
     }
 
     /** Server-side only! */
@@ -110,19 +107,9 @@ public class BasicTrainDisplayData {
             throw new RuntimeSideException(false);
         }
 
+        int carriagesCount = TrainUtils.getTrain(train).map(x -> x.carriages.size()).orElse(0);
+
         return TrainListener.getTrainData(train).map(data -> {
-            /*
-            final ScheduleSection section = data.getCurrentSection();
-            final ScheduleSection prevSection = section.previousSection();
-            ScheduleSection selectedSection = section;
-
-            boolean isAtStation = data.waitingAtStationIndex == data.getCurrentScheduleIndex();
-            boolean isFirstStationInSection = section.getFirstStop().map(x -> x.getEntryIndex() == data.getCurrentScheduleIndex()).orElse(false);
-
-            if (isFirstStationInSection && !isAtStation && prevSection.shouldIncludeNextStationOfNextSection()) {
-                selectedSection = prevSection;
-            }
-             */
             Map<ETrainStopState, StateData> dataByState = new HashMap<>(ETrainStopState.values().length);
             for (ETrainStopState state : ETrainStopState.values()) {
                 ScheduleSection section = state.resolveSection(data.getCurrentSection(), data.waitingAtStationTime, data.getCurrentScheduleIndex());
@@ -141,9 +128,9 @@ public class BasicTrainDisplayData {
                     new ArrayList<>(data.getStatus()),
                     data.isCancelled(),
                     dataByState,
-                    data.getTrain().carriages.size()
+                    carriagesCount
             );
-        }).orElse(empty());
+        }).orElse(empty(carriagesCount));
     }
 
     /** Server-side only! */
@@ -152,20 +139,9 @@ public class BasicTrainDisplayData {
             throw new RuntimeSideException(false);
         }
 
+        int carriagesCount = TrainUtils.getTrain(stop.getTrainId()).map(x -> x.carriages.size()).orElse(0);
+
         return TrainListener.getTrainData(stop.getTrainId()).map(data -> {
-            /*
-            final ScheduleSection section = data.getCurrentSection();
-            final ScheduleSection prevSection = section.previousSection();
-            ScheduleSection selectedSection = section;
-
-            boolean isAtStation = data.waitingAtStationIndex == data.getCurrentScheduleIndex();
-            boolean isFirstStationInSection = section.getFirstStop().map(x -> x.getEntryIndex() == data.getCurrentScheduleIndex()).orElse(false);
-
-            if (isFirstStationInSection && !isAtStation && prevSection.shouldIncludeNextStationOfNextSection()) {
-                selectedSection = prevSection;
-            }
-
-             */
             Map<ETrainStopState, StateData> dataByState = new HashMap<>(ETrainStopState.values().length);
             for (ETrainStopState state : ETrainStopState.values()) {
                 ScheduleSection section = state.resolveSection(data.getSectionForIndex(stop.getScheduleIndex()), data.waitingAtStationIndex, stop.getScheduleIndex());
@@ -179,14 +155,14 @@ public class BasicTrainDisplayData {
             }
 
             return new BasicTrainDisplayData(
-                stop.getTrainId(),
-                stop.getTrainIcon(),
-                new ArrayList<>(data.getStatus()),
-                data.isCancelled(),
-                dataByState,
-                data.getTrain().carriages.size()
+                    stop.getTrainId(),
+                    stop.getTrainIcon(),
+                    new ArrayList<>(data.getStatus()),
+                    data.isCancelled(),
+                    dataByState,
+                    carriagesCount
             );
-        }).orElse(empty());
+        }).orElse(empty(carriagesCount));
     }
 
     public UUID getId() {

--- a/common/src/main/java/de/mrjulsen/crn/data/train/portable/BasicTrainDisplayData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/portable/BasicTrainDisplayData.java
@@ -184,7 +184,7 @@ public class BasicTrainDisplayData {
                 new ArrayList<>(data.getStatus()),
                 data.isCancelled(),
                 dataByState,
-                stop.getTrainCarriages()
+                data.getTrain().carriages.size()
             );
         }).orElse(empty());
     }

--- a/common/src/main/java/de/mrjulsen/crn/data/train/portable/StationDisplayData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/portable/StationDisplayData.java
@@ -99,7 +99,7 @@ public class StationDisplayData {
     }
 
     public static StationDisplayData empty() {
-        return new StationDisplayData(BasicTrainDisplayData.empty(), TrainStopDisplayData.empty(), "", false, false, false, false, List.of(), State.OUT_OF_SERVICE);
+        return new StationDisplayData(BasicTrainDisplayData.empty(0), TrainStopDisplayData.empty(), "", false, false, false, false, List.of(), State.OUT_OF_SERVICE);
     }
 
     /** Server-side only! */

--- a/common/src/main/java/de/mrjulsen/crn/data/train/portable/TrainDisplayData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/train/portable/TrainDisplayData.java
@@ -94,8 +94,8 @@ public class TrainDisplayData {
     private static final String NBT_DO_NOT_BOARD = "DoNotBoard";
     private static final String NBT_STATE = "State";
 
-    private TrainDisplayData() {
-        this.trainData = BasicTrainDisplayData.empty();
+    private TrainDisplayData(BasicTrainDisplayData trainData) {
+        this.trainData = trainData;
         this.stops = List.of();
         this.currentScheduleIndex = -1;
         this.speed = 0;
@@ -160,8 +160,8 @@ public class TrainDisplayData {
         this.state = state;
     }
 
-    public static TrainDisplayData empty() {
-        return new TrainDisplayData();
+    public static TrainDisplayData empty(int carriages) {
+        return new TrainDisplayData(BasicTrainDisplayData.empty(carriages));
     }
 
     /** Server-side only! */
@@ -170,7 +170,7 @@ public class TrainDisplayData {
             throw new RuntimeSideException(false);
         }
         if (train.runtime.getSchedule() == null) {
-            return empty();
+            return empty(train.carriages.size());
         }
 
         return TrainListener.getTrainData(train.id).map(data -> {
@@ -255,7 +255,7 @@ public class TrainDisplayData {
                 isAtStation,
                 state
             );
-        }).orElse(empty());        
+        }).orElse(empty(train.carriages.size()));
     }
 
     public BasicTrainDisplayData getTrainData() {
@@ -349,7 +349,7 @@ public class TrainDisplayData {
     public static TrainDisplayData fromNbt(CompoundTag nbt) {
         
         if (nbt.getBoolean(NBT_OUT_OF_SERVICE) && !nbt.getBoolean(NBT_DO_NOT_BOARD)) {
-            return new TrainDisplayData();
+            return new TrainDisplayData(nbt.contains(NBT_TRAIN) ? BasicTrainDisplayData.fromNbt(nbt.getCompound(NBT_TRAIN)) : BasicTrainDisplayData.empty(0));
         }
         
         return new TrainDisplayData(

--- a/common/src/main/java/de/mrjulsen/crn/network/packets/pain/GetTrainDisplayDataPacketData.java
+++ b/common/src/main/java/de/mrjulsen/crn/network/packets/pain/GetTrainDisplayDataPacketData.java
@@ -42,7 +42,7 @@ public class GetTrainDisplayDataPacketData {
     }
 
     public static class Response extends NetworkPacketData {
-        private TrainDisplayData data = TrainDisplayData.empty();
+        private TrainDisplayData data = TrainDisplayData.empty(0);
 
         public Response(DLStatus status) {
             super(status);
@@ -72,7 +72,7 @@ public class GetTrainDisplayDataPacketData {
     public static Response handle(Request packet, NetworkPacketContext context) {
         Optional<Train> trainOpt = TrainUtils.getTrain(packet.id);
         if (trainOpt.isEmpty() || !TrainUtils.isTrainUsable(trainOpt.get()) || GlobalSettings.getInstance().isTrainBlacklisted(trainOpt.get())) {
-            return new Response(TrainDisplayData.empty());
+            return new Response(TrainDisplayData.empty(trainOpt.map(x -> x.carriages.size()).orElse(0)));
         }
         return new Response(TrainDisplayData.of(trainOpt.get()));
     }

--- a/common/src/main/java/de/mrjulsen/crn/registry/ModDisplayTypes.java
+++ b/common/src/main/java/de/mrjulsen/crn/registry/ModDisplayTypes.java
@@ -69,11 +69,11 @@ public final class ModDisplayTypes {
 
     public static final DisplayTypeResourceKey SIMPLE_TEXT = AdvancedDisplaysRegistry.register(
         EDisplayType.STATIC_TEXT, "simple_text",
-        SimpleStaticTextDisplaySettings::new, BERStaticText::new, new DisplayProperties(true, null));
+        SimpleStaticTextDisplaySettings::new, BERStaticText::new, new DisplayProperties(true, be -> 16));
 
     public static final DisplayTypeResourceKey RICH_TEXT = AdvancedDisplaysRegistry.register(
         EDisplayType.STATIC_TEXT, "rich_text",
-        StaticTextDisplaySettings::new, BERRichText::new, new DisplayProperties(false, null));
+        StaticTextDisplaySettings::new, BERRichText::new, new DisplayProperties(false, be -> 16));
     
     @Deprecated
     public static DisplayTypeResourceKey legacy_getKeyForType(EDisplayType type, EDisplayInfo info) {

--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -1,21 +1,112 @@
 package de.mrjulsen.crn.util;
 
-import java.util.Map;
-import java.util.function.Supplier;
+import java.util.List;
 
+import de.mrjulsen.crn.block.blockentity.AdvancedDisplayBlockEntity;
+import de.mrjulsen.crn.block.display.properties.components.ITrainStopTypeSetting;
 import de.mrjulsen.crn.config.ModClientConfig;
+import de.mrjulsen.crn.data.train.ETrainStopState;
+import de.mrjulsen.crn.data.train.portable.StationDisplayData;
+import de.mrjulsen.crn.data.train.portable.TrainDisplayData;
+import de.mrjulsen.crn.data.train.portable.TrainStopDisplayData;
 import de.mrjulsen.mcdragonlib.DragonLib;
 import de.mrjulsen.mcdragonlib.util.time.DLTime;
 import de.mrjulsen.mcdragonlib.util.time.TimeContext;
+import org.jetbrains.annotations.Nullable;
 
 public class VariableManager {
+    private static String handleStopover(List<TrainStopDisplayData> list, int i, String variable) {
+        if (i < 0 || i >= list.size()) return handleStopover(null, variable);
+        return handleStopover(list.get(i), variable);
+    }
+    
+    private static String handleStopover(@Nullable TrainStopDisplayData data, String variable) {
+        boolean eta = variable.endsWith("_eta");
 
-    private static final Map<String, Supplier<String>> variables = Map.ofEntries(
-        Map.entry("time", () -> new DLTime(DragonLib.getCurrentWorldTime(), DLTime.defaultTimeSystem()).format(ModClientConfig.TIME_FORMAT.get().getFormat(), TimeContext.INGAME, DLTime.defaultTimeSystem()))
-    );
+        // this should only return null if the variable is invalid so don't anyone
+        // dare replace the tertiary statements with a single guard statement
+        // - C1200
+        return switch (variable) {
+            case "station_name" -> data == null ? "" : data.getRealTimeStation().tagName();
+            case "platform" -> data == null ? "" : data.getRealTimeStation().info().platform();
+            case "arrival", "arrival_eta" -> data == null ? "" : ModUtils.formatTime(data.getScheduledArrivalTime(), eta);
+            case "departure", "departure_eta" -> data == null ? "" : ModUtils.formatTime(data.getScheduledDepartureTime(), eta);
+            default -> null;
+        };
+    }
 
-    public static String replacePlaceholders(String text) {
-        
+    private static String handleTrainEntry(List<StationDisplayData> list, int i, String variable) {
+        if (i >= list.size()) return handleTrainEntry(null, variable);
+        return handleTrainEntry(list.get(i), variable);
+    }
+
+    private static String handleTrainEntry(@Nullable StationDisplayData data, String variable) {
+        ITrainStopTypeSetting.ETrainStopType t = ITrainStopTypeSetting.ETrainStopType.ALL;
+
+        // same rule as above applies
+
+        String maybeReplacement = handleStopover(data == null ? null : data.getStationData(), variable);
+        if (maybeReplacement != null) return maybeReplacement;
+
+        if (variable.matches("^stop\\d+$")) {
+            int n = Integer.parseInt(variable.substring(4));
+            if (data == null || n < 0 || n >= data.getStopovers().size()) return "";
+            return data.getStopovers().get(n);
+        }
+
+        return switch (variable) {
+            case "via" -> data == null ? "" : data.getStopovers().stream().reduce("", (a, b) -> a + ", " + b);
+            case "line" -> data == null ? "" : data.getTrainData().getName(ITrainStopTypeSetting.resolveStopState(data, t.showDepartures(data.isFirstStop()), t.showArrivals(data.isLastStop())));
+            case "origin" -> data == null ? "" : data.getFirstStopName();
+            case "destination" -> data == null ? "" : data.getStationData().getDestination();
+            case "carriages" -> data == null ? "" : "" + data.getTrainData().getCarriages();
+            default -> null;
+        };
+    }
+
+    private static String getReplacement(AdvancedDisplayBlockEntity blockEntity, String variable) {
+        // generic
+        DLTime time = new DLTime(DragonLib.getCurrentWorldTime(), DLTime.defaultTimeSystem());
+        if (variable.equals("time")) {
+            return time.format(ModClientConfig.TIME_FORMAT.get().getFormat(), TimeContext.INGAME, DLTime.defaultTimeSystem());
+        } else if (variable.equals("day")) {
+            return "" + (long)time.toGameDays(DLTime.defaultTimeSystem());
+        }
+
+        // on-board
+        TrainDisplayData train = blockEntity.getTrainData();
+
+        if (variable.equals("via")) {
+            return train.getStopovers().stream().reduce("", (a, b) -> a + ", " + b.getRealTimeStation().tagName(), (a, b) -> a + ", " + b);
+        } else if (variable.equals("line")) {
+            return train.getTrainData().getName(ETrainStopState.beforeArrival(!train.isWaitingAtStation()));
+        } else if (variable.equals("carriages")) {
+            return "" + train.getTrainData().getCarriages();
+        }else if (variable.startsWith("origin.")) {
+            return handleStopover(train.getAllStops(), 0, variable.substring(7));
+        } else if (variable.startsWith("destination.")) {
+            return handleStopover(train.getAllStops(), train.getAllStops().size() - 1, variable.substring(12));
+        } else if (variable.startsWith("next.")) {
+            if (train.getStopovers().isEmpty())
+                return handleStopover(train.getAllStops(), train.getAllStops().size() - 1, variable.substring(5));
+            return handleStopover(train.getStopovers(), 0, variable.substring(5));
+        } else if (variable.matches("^stop\\d+\\..+")) {
+            int dot = variable.indexOf(".");
+            int n = Integer.parseInt(variable.substring(4, dot));
+            return handleStopover(train.getStopovers(), n, variable.substring(dot + 1));
+        }
+
+        // station
+        if (variable.matches("^train\\d+\\..+")) {
+            int dot = variable.indexOf(".");
+            int n = Integer.parseInt(variable.substring(5, dot));
+            return handleTrainEntry(blockEntity.getStops(), n, variable.substring(dot + 1));
+        }
+
+        return null;
+    }
+
+    public static String replacePlaceholders(String text, AdvancedDisplayBlockEntity blockEntity) {
         StringBuilder result = new StringBuilder();
         int length = text.length();
 
@@ -33,9 +124,8 @@ public class VariableManager {
                 int end = text.indexOf('%', i + 1);
                 if (end > i + 1) {
                     String key = text.substring(i + 1, end);
-                    Supplier<String> supplier = variables.get(key);
-                    if (supplier != null) {
-                        String replacement = supplier.get();
+                    String replacement = getReplacement(blockEntity, key);
+                    if (replacement != null) {
                         result.append(replacement);
                     } else {
                         // Key nicht gefunden: lasse Platzhalter unverändert
@@ -52,6 +142,7 @@ public class VariableManager {
     }
 
 
+    /*
     public static boolean hasValidPlaceholders(String text) {
         int length = text.length();
         for (int i = 0; i < length; i++) {
@@ -79,4 +170,5 @@ public class VariableManager {
         }
         return true;
     }
+    */
 }

--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -74,33 +74,37 @@ public class VariableManager {
         }
 
         // on-board
-        TrainDisplayData train = blockEntity.getTrainData();
+        if (blockEntity.assembledOnContraption) {
+            TrainDisplayData train = blockEntity.getTrainData();
 
-        if (variable.equals("via")) {
-            return train.getStopovers().stream().reduce("", (a, b) -> a + ", " + b.getRealTimeStation().tagName(), (a, b) -> a + ", " + b);
-        } else if (variable.equals("line")) {
-            return train.getTrainData().getName(ETrainStopState.beforeArrival(!train.isWaitingAtStation()));
-        } else if (variable.equals("carriages")) {
-            return "" + train.getTrainData().getCarriages();
-        }else if (variable.startsWith("origin.")) {
-            return handleStopover(train.getAllStops(), 0, variable.substring(7));
-        } else if (variable.startsWith("destination.")) {
-            return handleStopover(train.getAllStops(), train.getAllStops().size() - 1, variable.substring(12));
-        } else if (variable.startsWith("next.")) {
-            if (train.getStopovers().isEmpty())
-                return handleStopover(train.getAllStops(), train.getAllStops().size() - 1, variable.substring(5));
-            return handleStopover(train.getStopovers(), 0, variable.substring(5));
-        } else if (variable.matches("^stop\\d+\\..+")) {
-            int dot = variable.indexOf(".");
-            int n = Integer.parseInt(variable.substring(4, dot));
-            return handleStopover(train.getStopovers(), n, variable.substring(dot + 1));
+            if (variable.equals("via")) {
+                return train.getStopovers().stream().reduce("", (a, b) -> a + ", " + b.getRealTimeStation().tagName(), (a, b) -> a + ", " + b);
+            } else if (variable.equals("line")) {
+                return train.getTrainData().getName(ETrainStopState.beforeArrival(!train.isWaitingAtStation()));
+            } else if (variable.equals("carriages")) {
+                return "" + train.getTrainData().getCarriages();
+            } else if (variable.startsWith("origin.")) {
+                return handleStopover(train.getAllStops(), 0, variable.substring(7));
+            } else if (variable.startsWith("destination.")) {
+                return handleStopover(train.getAllStops(), train.getAllStops().size() - 1, variable.substring(12));
+            } else if (variable.startsWith("next.")) {
+                if (train.getStopovers().isEmpty())
+                    return handleStopover(train.getAllStops(), train.getAllStops().size() - 1, variable.substring(5));
+                return handleStopover(train.getStopovers(), 0, variable.substring(5));
+            } else if (variable.matches("^stop\\d+\\..+")) {
+                int dot = variable.indexOf(".");
+                int n = Integer.parseInt(variable.substring(4, dot));
+                return handleStopover(train.getStopovers(), n, variable.substring(dot + 1));
+            }
         }
 
         // station
-        if (variable.matches("^train\\d+\\..+")) {
-            int dot = variable.indexOf(".");
-            int n = Integer.parseInt(variable.substring(5, dot));
-            return handleTrainEntry(blockEntity.getStops(), n, variable.substring(dot + 1));
+        if (!blockEntity.assembledOnContraption) {
+            if (variable.matches("^train\\d+\\..+")) {
+                int dot = variable.indexOf(".");
+                int n = Integer.parseInt(variable.substring(5, dot));
+                return handleTrainEntry(blockEntity.getStops(), n, variable.substring(dot + 1));
+            }
         }
 
         return null;


### PR DESCRIPTION
On top of the already existing %time% placeholder, this PR adds:
- Generic placeholders
  - `day` - the current in-game day
- On-board placeholders
  - `via` - a comma separated list of all stopovers
  - `line` - the train name or, if defined, the line name
  - `carriages` - the amount of carriages this train has
  - `origin.` (where the train started its journey) **OR**
    `destination.` (where the train will end its journey) **OR**
    `next.` (the next stop, includes the destination) **OR**
    `stopN.` (the following stops, where N=0 is the next stop, excludes the destination), followed by:
    - `station_name` - the arrival station
    - `platform` - the arrival platform number
    - `arrival` - arrival time in in-game hh:mm format
    - `departure` - departure time in in-game hh:mm format
    - `arrival_eta` - arrival time as an eta
    - `departure_eta` - departure time as an eta
- Station placeholders
  - `trainN.`, followed by:
    - `station_name` - the arrival station
    - `platform` - the arrival platform number
    - `arrival` - arrival time in in-game hh:mm format
    - `departure` - departure time in in-game hh:mm format
    - `arrival_eta` - arrival time as an eta
    - `departure_eta` - departure time as an eta
    - `via` - a comma separated list of all stopovers
    - `line` - the train name or, if defined, the line name
    - `origin` - where the train started its journey
    - `destination` - where the train will end its journey
    - `carriages` - the amount of carriages a train has
    - `stopN` - the following stops, where N=0 is the next stop

Todo:
- [x] fix carriages placeholder only showing 0 on station displays (help would be appreciated, i dont know what ive done wrong)