### PR TITLE
feat. Elevator Displays

### DIFF
--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
@@ -522,7 +522,7 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
         int minDistance = Integer.MAX_VALUE;
 
         for (var entry : ec.namesList) {
-            int contactY = entry.getFirst(); // Y-level piętra
+            int contactY = entry.getFirst();
             int distance = Math.abs(contactY - currentFloorY);
             
             if (distance < minDistance) {
@@ -558,7 +558,6 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
                 
                 String shortName = "", longName = "", shortNameDest = "", longNameDest = "";
 
-                // Wyciągamy nazwy z namesList zamiast z BlockEntity
                 for (var entry : elevator.namesList) {
                     int contactY = entry.getFirst();
                     if (contactY == closestY) {

--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
@@ -4,6 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.simibubi.create.content.contraptions.Contraption;
+import com.simibubi.create.content.contraptions.ControlledContraptionEntity;
+import com.simibubi.create.content.contraptions.elevator.ElevatorColumn;
+import com.simibubi.create.content.contraptions.elevator.ElevatorContactBlockEntity;
+import com.simibubi.create.content.contraptions.elevator.ElevatorContraption;
 import com.simibubi.create.content.decoration.copycat.CopycatBlockEntity;
 import com.simibubi.create.content.trains.display.FlapDisplayBlock;
 import com.simibubi.create.content.trains.entity.CarriageContraption;
@@ -27,6 +32,7 @@ import de.mrjulsen.crn.client.AdvancedDisplaysRegistry.DisplayTypeResourceKey;
 import de.mrjulsen.crn.client.ber.AdvancedDisplayRenderInstance;
 import de.mrjulsen.crn.config.ModClientConfig;
 import de.mrjulsen.crn.data.CarriageData;
+import de.mrjulsen.crn.data.ElevatorData;
 import de.mrjulsen.crn.data.TrainExitSide;
 import de.mrjulsen.crn.data.StationTag.ClientStationTag;
 import de.mrjulsen.crn.data.StationTag.StationInfo;
@@ -59,6 +65,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -111,6 +118,7 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
     private long lastRefreshedTime;
     private TrainDisplayData trainData = TrainDisplayData.empty(0);
     private CarriageData carriageData = new CarriageData(0, Direction.NORTH, false);
+    private ElevatorData elevatorData = new ElevatorData("", "", "", "", "");
     
     // OTHER
     private int syncTicks = 0;
@@ -182,6 +190,10 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
 
     public CarriageData getCarriageData() {
         return carriageData;
+    }
+
+    public ElevatorData getElevatorData() {
+        return elevatorData;
     }
 
     public long getLastRefreshedTime() {
@@ -502,8 +514,28 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
         }
     }
 
+    public int getClosestFloor(ElevatorContraption ec) {
+        double currentY = ec.entity.getY();
+        int currentFloorY = Mth.floor(0.5f + (float)currentY) + ec.getContactYOffset();
+
+        int closest = -1;
+        int minDistance = Integer.MAX_VALUE;
+
+        for (var entry : ec.namesList) {
+            int contactY = entry.getFirst(); // Y-level piętra
+            int distance = Math.abs(contactY - currentFloorY);
+            
+            if (distance < minDistance) {
+                minDistance = distance;
+                closest = contactY;
+            }
+        }
+        
+        return closest;
+    }
+
     @Override
-    public void contraptionTick(Level level, BlockPos pos, BlockState state, CarriageContraption carriage) {
+    public void contraptionTick(Level level, BlockPos pos, BlockState state, Contraption contraption) {
         assembledOnContraption = true;
         getRenderer().tick(level, pos, state, this);
 
@@ -520,7 +552,44 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
         if (level.isClientSide && syncTicks <= 0) {
             syncTicks = ModClientConfig.DISPLAY_REFRESH_RATE.get();
 
-            if (!(carriage.entity instanceof CarriageContraptionEntity carriageContraption)) {
+            if (contraption instanceof ElevatorContraption elevator) {
+                int targetY = elevator.clientYTarget;
+                int closestY = getClosestFloor(elevator);
+                
+                String shortName = "", longName = "", shortNameDest = "", longNameDest = "";
+
+                // Wyciągamy nazwy z namesList zamiast z BlockEntity
+                for (var entry : elevator.namesList) {
+                    int contactY = entry.getFirst();
+                    if (contactY == closestY) {
+                        shortName = entry.getValue().getFirst();
+                        longName = entry.getValue().getSecond();
+                    }
+                    if (contactY == targetY) {
+                        shortNameDest = entry.getValue().getFirst();
+                        longNameDest = entry.getValue().getSecond();
+                    }
+                }
+
+                String directionSign = "";
+                if (!elevator.arrived) {
+                    double actualY = elevator.entity.getY() + elevator.getContactYOffset();
+                    if (targetY > actualY + 0.5) directionSign = "up";
+                    else if (targetY < actualY - 0.5) directionSign = "dn";
+                }
+
+                ElevatorData newData = new ElevatorData(shortName.toString(), longName.toString(), shortNameDest.toString(), longNameDest.toString(), directionSign.toString());
+                
+                if (!newData.equals(this.elevatorData)) {
+                    this.elevatorData = newData;
+                    getRenderer().update(level, pos, state, this, EUpdateReason.DATA_CHANGED);
+                }
+            }
+
+            if (!(contraption.entity instanceof CarriageContraptionEntity carriageContraption)) {
+                return;
+            }
+            if (!(contraption instanceof CarriageContraption carriage)) {
                 return;
             }
 

--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/AdvancedDisplayBlockEntity.java
@@ -33,6 +33,7 @@ import de.mrjulsen.crn.client.ber.AdvancedDisplayRenderInstance;
 import de.mrjulsen.crn.config.ModClientConfig;
 import de.mrjulsen.crn.data.CarriageData;
 import de.mrjulsen.crn.data.ElevatorData;
+import de.mrjulsen.crn.data.ElevatorMovementType;
 import de.mrjulsen.crn.data.TrainExitSide;
 import de.mrjulsen.crn.data.StationTag.ClientStationTag;
 import de.mrjulsen.crn.data.StationTag.StationInfo;
@@ -118,7 +119,7 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
     private long lastRefreshedTime;
     private TrainDisplayData trainData = TrainDisplayData.empty(0);
     private CarriageData carriageData = new CarriageData(0, Direction.NORTH, false);
-    private ElevatorData elevatorData = new ElevatorData("", "", "", "", "");
+    private ElevatorData elevatorData = new ElevatorData("", "", "", "", ElevatorMovementType.STANDING_STILL);
     
     // OTHER
     private int syncTicks = 0;
@@ -570,14 +571,14 @@ public class AdvancedDisplayBlockEntity extends CopycatBlockEntity implements
                     }
                 }
 
-                String directionSign = "";
+                ElevatorMovementType directionSign = ElevatorMovementType.STANDING_STILL;
                 if (!elevator.arrived) {
                     double actualY = elevator.entity.getY() + elevator.getContactYOffset();
-                    if (targetY > actualY + 0.5) directionSign = "up";
-                    else if (targetY < actualY - 0.5) directionSign = "dn";
+                    if (targetY > actualY + 0.5) directionSign = ElevatorMovementType.GOING_UP;
+                    else if (targetY < actualY - 0.5) directionSign = ElevatorMovementType.GOING_DOWN;
                 }
 
-                ElevatorData newData = new ElevatorData(shortName.toString(), longName.toString(), shortNameDest.toString(), longNameDest.toString(), directionSign.toString());
+                ElevatorData newData = new ElevatorData(shortName.toString(), longName.toString(), shortNameDest.toString(), longNameDest.toString(), directionSign);
                 
                 if (!newData.equals(this.elevatorData)) {
                     this.elevatorData = newData;

--- a/common/src/main/java/de/mrjulsen/crn/block/blockentity/IContraptionBlockEntity.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/blockentity/IContraptionBlockEntity.java
@@ -1,6 +1,6 @@
 package de.mrjulsen.crn.block.blockentity;
 
-import com.simibubi.create.content.trains.entity.CarriageContraption;
+import com.simibubi.create.content.contraptions.Contraption;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -13,7 +13,7 @@ public interface IContraptionBlockEntity<T extends BlockEntity> {
      * @param level
      * @param pos
      * @param state
-     * @param carriage
+     * @param contraption
      */
-    void contraptionTick(Level level, BlockPos pos, BlockState state, CarriageContraption carriage);
+    void contraptionTick(Level level, BlockPos pos, BlockState state, Contraption contraption);
 }

--- a/common/src/main/java/de/mrjulsen/crn/data/ElevatorData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/ElevatorData.java
@@ -1,0 +1,3 @@
+package de.mrjulsen.crn.data;
+
+public record ElevatorData(String currentShortName, String currentLongName, String destinationShortName, String destinationLongName, String sign) {}

--- a/common/src/main/java/de/mrjulsen/crn/data/ElevatorData.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/ElevatorData.java
@@ -1,3 +1,3 @@
 package de.mrjulsen.crn.data;
 
-public record ElevatorData(String currentShortName, String currentLongName, String destinationShortName, String destinationLongName, String sign) {}
+public record ElevatorData(String currentShortName, String currentLongName, String destinationShortName, String destinationLongName, ElevatorMovementType sign) {}

--- a/common/src/main/java/de/mrjulsen/crn/data/ElevatorMovementType.java
+++ b/common/src/main/java/de/mrjulsen/crn/data/ElevatorMovementType.java
@@ -1,0 +1,23 @@
+package de.mrjulsen.crn.data;
+
+public enum ElevatorMovementType {
+    STANDING_STILL("", ""),
+    GOING_UP("↑", "▲"),
+    GOING_DOWN("↓", "▼");
+
+    final String arrow;
+    final String triangle;
+
+    ElevatorMovementType(String arrow, String triangle) {
+        this.arrow = arrow;
+        this.triangle = triangle;
+    }
+
+    public String getArrow() {
+        return arrow;
+    }
+
+    public String getTriangle() {
+        return triangle;
+    }
+}

--- a/common/src/main/java/de/mrjulsen/crn/mixin/MountedStorageManagerMixin.java
+++ b/common/src/main/java/de/mrjulsen/crn/mixin/MountedStorageManagerMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
 import com.simibubi.create.content.contraptions.MountedStorageManager;
+import com.simibubi.create.content.contraptions.elevator.ElevatorContraption;
 import com.simibubi.create.content.trains.entity.CarriageContraption;
 
 import de.mrjulsen.crn.CRNPlatformSpecific;
@@ -22,7 +23,7 @@ public class MountedStorageManagerMixin {
 
     @Inject(method = "tick", remap = false, at = @At(value = "HEAD"))
     public void onEntityTick(AbstractContraptionEntity entity, CallbackInfo ci) {
-        if (entity.getContraption() instanceof CarriageContraption carriage) {
+        if (entity.getContraption() instanceof CarriageContraption || entity.getContraption() instanceof ElevatorContraption) {
             Set<BlockEntity> beList = new LinkedHashSet<>();
 
             for (StructureBlockInfo info : entity.getContraption().getBlocks().values()) {
@@ -34,7 +35,7 @@ public class MountedStorageManagerMixin {
 
             for (BlockEntity be : beList) {            
                 if (be instanceof IContraptionBlockEntity tile) {
-                    tile.contraptionTick(entity.level(), be.getBlockPos(), be.getBlockState(), carriage);
+                    tile.contraptionTick(entity.level(), be.getBlockPos(), be.getBlockState(), entity.getContraption());
                 }
             }
 

--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -75,6 +75,32 @@ public class VariableManager {
 
         // on-board
         if (blockEntity.assembledOnContraption) {
+            if (blockEntity.getElevatorData() != null) {
+                // elevator
+                if (variable.equals("elevator.current.short")) {
+                    // Used only because the format %elevator.current.short% %elevator.current.sign% fails because short is often an integer.
+                    return blockEntity.getElevatorData().currentShortName() + "\u200C";
+                } else if (variable.equals("elevator.current.long")) {
+                    return blockEntity.getElevatorData().currentLongName() + "\u200C";
+                } else if (variable.equals("elevator.destination.short")) {
+                    return blockEntity.getElevatorData().destinationShortName() + "\u200C";
+                } else if (variable.equals("elevator.destination.long")) {
+                    return blockEntity.getElevatorData().destinationLongName() + "\u200C";
+                } else if (variable.equals("elevator.sign")) {
+                    if (blockEntity.getElevatorData().sign() == "up")
+                        return "↑";
+                    else if (blockEntity.getElevatorData().sign() == "dn")
+                        return "↓";
+                    else return "";
+                } else if (variable.equals("elevator.sign.triangle")) {
+                    if (blockEntity.getElevatorData().sign() == "up")
+                        return "▲";
+                    else if (blockEntity.getElevatorData().sign() == "dn")
+                        return "▼";
+                    else return "";
+                } 
+            }
+
             TrainDisplayData train = blockEntity.getTrainData();
 
             if (variable.equals("via")) {

--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -87,17 +87,9 @@ public class VariableManager {
                 } else if (variable.equals("elevator.destination.long")) {
                     return blockEntity.getElevatorData().destinationLongName() + "\u200C";
                 } else if (variable.equals("elevator.sign")) {
-                    if (blockEntity.getElevatorData().sign() == "up")
-                        return "↑";
-                    else if (blockEntity.getElevatorData().sign() == "dn")
-                        return "↓";
-                    else return "";
+                    return blockEntity.getElevatorData().sign().getArrow();
                 } else if (variable.equals("elevator.sign.triangle")) {
-                    if (blockEntity.getElevatorData().sign() == "up")
-                        return "▲";
-                    else if (blockEntity.getElevatorData().sign() == "dn")
-                        return "▼";
-                    else return "";
+                    return blockEntity.getElevatorData().sign().getTriangle();
                 } 
             }
 


### PR DESCRIPTION
Adds the ability to use displays in elevators.
Available placeholders:
%elevator.current.short% // Short name of the current floor eg. 0
%elevator.current.long% // Long name of the current floor eg. Main Lobby
%elevator.destination.short% // Short name of the floor the elevator is heading to, eg. 21
%elevator.destination.long% // Long name of the floor the elevator is heading, eg. Gym
%elevator.sign% // Arrows indicating if the elevator is moving up or down
%elevator.sign.triangle% // The same thing as above but using a different pair of characters.