### PR TITLE
fix crash when rich text is updated and rendered simultaneously

### DIFF
--- a/common/src/main/java/de/mrjulsen/crn/client/ber/variants/BERRichText.java
+++ b/common/src/main/java/de/mrjulsen/crn/client/ber/variants/BERRichText.java
@@ -65,7 +65,7 @@ public class BERRichText implements AbstractAdvancedDisplayRenderer<StaticTextDi
         }
         getDisplaySettings(blockEntity).verifyComponents();
         List<TextComponent> components = getDisplaySettings(blockEntity).getComponents();
-        this.labels = new BERLabel[components.size()];
+        BERLabel[] labels = new BERLabel[components.size()];
 
         for (int i = 0; i < components.size(); i++) {
             TextComponent component = components.get(i);
@@ -89,7 +89,9 @@ public class BERRichText implements AbstractAdvancedDisplayRenderer<StaticTextDi
             label.fullBackground.set(component.isFullLabelBackgroundColor());
             label.glowing.set(blockEntity.isGlowing());
 
-            this.labels[i] = label;
+            labels[i] = label;
         }
+
+        this.labels = labels;
     }
 }


### PR DESCRIPTION
see https://discord.com/channels/1187795163116998736/1501311310217089054

i left the game running for just over an hour and it didnt crash or log any errors, typically it would at least log an error within like 5 minutes