### PR TITLE
add option to prevent scale and pos reset on display link update

### DIFF
--- a/common/src/main/java/de/mrjulsen/crn/block/display/AdvancedDisplayTarget.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/display/AdvancedDisplayTarget.java
@@ -173,11 +173,13 @@ public class AdvancedDisplayTarget extends DisplayTarget {
 							component.setStaticText("{\"text\":\"\"}");
 						} else
 							component.setStaticText(Component.Serializer.toJson(text.get(i)));
-						component.setTextAlignment(ETextAlignment.LEFT);
-						component.setXScale(0.4f);
-						component.setMinXScale(0.4f);
-						component.setYScale(0.4f);
-						component.setY((componentIndex) * 5.5f);
+						if (!component.shouldRetainScaleAndPos()) {
+							component.setTextAlignment(ETextAlignment.LEFT);
+							component.setXScale(0.4f);
+							component.setMinXScale(0.4f);
+							component.setYScale(0.4f);
+							component.setY((componentIndex) * 5.5f);
+						}
 						settings.setComponent(componentIndex, component);
 					}
 					ModCommonEvents.getCurrentServer()

--- a/common/src/main/java/de/mrjulsen/crn/block/display/properties/StaticTextDisplaySettings.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/display/properties/StaticTextDisplaySettings.java
@@ -6,12 +6,7 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
-import de.mrjulsen.crn.block.display.properties.components.GuiBuilderWrapper;
-import de.mrjulsen.crn.block.display.properties.components.IStaticTextSetting;
-import de.mrjulsen.crn.block.display.properties.components.ITextBackgroundColorSetting;
-import de.mrjulsen.crn.block.display.properties.components.ITextPosSetting;
-import de.mrjulsen.crn.block.display.properties.components.ITextScaleSetting;
-import de.mrjulsen.crn.block.display.properties.components.ITextWidthSetting;
+import de.mrjulsen.crn.block.display.properties.components.*;
 import de.mrjulsen.crn.client.gui.widgets.modular.GuiBuilderContext;
 import de.mrjulsen.mcdragonlib.data.ETextAlignment;
 import de.mrjulsen.mcdragonlib.util.DLColor;
@@ -20,7 +15,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 
-public class StaticTextDisplaySettings extends BasicDisplaySettings implements IStaticTextSetting, ITextScaleSetting, ITextPosSetting, ITextWidthSetting, ITextBackgroundColorSetting {
+public class StaticTextDisplaySettings extends BasicDisplaySettings implements IStaticTextSetting, ITextScaleSetting, ITextPosSetting, ITextWidthSetting, ITextBackgroundColorSetting, IRetainScaleAndPosSetting {
 
     public static class TextComponent {
         String staticText = "";
@@ -34,6 +29,7 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
         ETextAlignment alignment = DEFAULT_TEXT_ALIGNMENT;
         DLColor backgroundColor = DEFAULT_BG_COLOR;
         boolean fullLabelColor = DEFAULT_FULL_LABEL_COLOR;
+        boolean retainScalePos = DEFAULT_RETAIN_SCALE_POS;
 
         public TextComponent() {
 
@@ -131,6 +127,14 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
             this.fullLabelColor = b;
         }
 
+        public boolean shouldRetainScaleAndPos() {
+            return this.retainScalePos;
+        }
+
+        public void setShouldRetainScaleAndPos(boolean v) {
+            this.retainScalePos = v;
+        }
+
         public static TextComponent fromNbt(CompoundTag nbt) {
             TextComponent comp = new TextComponent();
             if (nbt.contains(NBT_TEXT)) comp.staticText = nbt.getString(NBT_TEXT);
@@ -144,6 +148,7 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
             if (nbt.contains(NBT_TEXT_ALIGNMENT)) comp.alignment = ETextAlignment.getById(nbt.getInt(NBT_TEXT_ALIGNMENT));
             if (nbt.contains(NBT_TEXT_BG_COLOR)) comp.backgroundColor = DLColor.fromInt(nbt.getInt(NBT_TEXT_BG_COLOR));
             if (nbt.contains(NBT_FULL_LABEL_COLOR)) comp.fullLabelColor = nbt.getBoolean(NBT_FULL_LABEL_COLOR);
+            if (nbt.contains(NBT_RETAIN_SCALE_POS)) comp.retainScalePos = nbt.getBoolean(NBT_RETAIN_SCALE_POS);
             return comp;
         }
     
@@ -160,6 +165,7 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
             nbt.putInt(NBT_TEXT_ALIGNMENT, alignment.getId());
             nbt.putInt(NBT_TEXT_BG_COLOR, backgroundColor.getAsARGB());
             nbt.putBoolean(NBT_FULL_LABEL_COLOR, fullLabelColor);
+            nbt.putBoolean(NBT_RETAIN_SCALE_POS, retainScalePos);
             return nbt;
         }
 
@@ -221,6 +227,7 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
         this.buildTextScaleGui(context);
         this.buildTextMaxWidthGui(context);
         this.buildTextBackgroundColorGui(context);
+        this.buildRetainGui(context);
     }
 
     @Override
@@ -238,6 +245,7 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
                 copyTextPosSettings(oldSettings);
                 copyTextMaxWidthSetting(oldSettings);
                 copyTextBackgroundColorSettings(oldSettings);
+                copyRetainSettings(oldSettings);
             }
         } else { 
                
@@ -246,6 +254,7 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
             copyTextPosSettings(oldSettings);
             copyTextMaxWidthSetting(oldSettings);
             copyTextBackgroundColorSettings(oldSettings);
+            copyRetainSettings(oldSettings);
         }
         setSelectedComponentIndex(currentIndex);
     }
@@ -390,6 +399,16 @@ public class StaticTextDisplaySettings extends BasicDisplaySettings implements I
     @Override
     public void setFullLabelBackgroundColor(boolean b) {
         getSelectedComponent().fullLabelColor = b;
+    }
+
+    @Override
+    public boolean shouldRetainScaleAndPos() {
+        return getSelectedComponent().retainScalePos;
+    }
+
+    @Override
+    public void setShouldRetainScaleAndPos(boolean v) {
+        getSelectedComponent().retainScalePos = v;
     }
 
     public void verifyComponents() {

--- a/common/src/main/java/de/mrjulsen/crn/block/display/properties/components/GuiBuilderWrapper.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/display/properties/components/GuiBuilderWrapper.java
@@ -32,7 +32,6 @@ import de.mrjulsen.mcdragonlib.client.gui.widgets.components.DLTooltip;
 import de.mrjulsen.mcdragonlib.client.gui.widgets.layout.FlowLayout;
 import de.mrjulsen.mcdragonlib.client.gui.widgets.layout.FlowLayout.Direction;
 import de.mrjulsen.mcdragonlib.data.ETextAlignment;
-import de.mrjulsen.mcdragonlib.data.ITranslatableEnum;
 import de.mrjulsen.mcdragonlib.util.DLUtils;
 import de.mrjulsen.mcdragonlib.util.TextUtils;
 import de.mrjulsen.mcdragonlib.util.Holder.MutableHolder;
@@ -743,6 +742,24 @@ public class GuiBuilderWrapper {
         });
         fullLineBox.tooltip.set(new DLTooltip(List.of(ITextBackgroundColorSetting.txtFullSizeDescription), 200));
         line.addComponent(fullLineBox);
+    }
+
+    static void buildRetainGui(IRetainScaleAndPosSetting setting, GuiBuilderContext context) {
+        DLPanel line = context.container().addLine(IRetainScaleAndPosSetting.GUI_LINE_RETAIN_NAME);
+
+        IconSlotWidget icon = line.addComponent(new IconSlotWidget(0, 0));
+        icon.icon.set(ModGuiIcons.LOCKED.getAsSprite(16, 16));
+
+        DLCheckBox retainBox = new DLCheckBox(0, 0, 0, CreateButton.HEIGHT);
+        retainBox.text.set(IRetainScaleAndPosSetting.txtRetain);
+        retainBox.checked.set(setting.shouldRetainScaleAndPos());
+        retainBox.layoutContraint.set(FlowLayout.FlowConstraint.FILL);
+        retainBox.addEventListener(DLToggleButton.CheckedChangedEvent.class, (s, e) -> {
+            setting.setShouldRetainScaleAndPos(e.checked());
+            return false;
+        });
+        retainBox.tooltip.set(new DLTooltip(List.of(IRetainScaleAndPosSetting.txtRetainDescription), 200));
+        line.addComponent(retainBox);
     }
     
 }

--- a/common/src/main/java/de/mrjulsen/crn/block/display/properties/components/IRetainScaleAndPosSetting.java
+++ b/common/src/main/java/de/mrjulsen/crn/block/display/properties/components/IRetainScaleAndPosSetting.java
@@ -1,0 +1,36 @@
+package de.mrjulsen.crn.block.display.properties.components;
+
+import de.mrjulsen.crn.CreateRailwaysNavigator;
+import de.mrjulsen.crn.block.display.properties.IDisplaySettings;
+import de.mrjulsen.crn.client.gui.widgets.modular.GuiBuilderContext;
+import de.mrjulsen.mcdragonlib.util.TextUtils;
+import net.minecraft.network.chat.MutableComponent;
+
+/**
+ * For data conversion: Indicates that this class adopts the original
+ * property {@code timeDisplay} from the Advanced Displays.
+ * If the class should adopt this property, this interface must be
+ * implemented or the value will not be converted!
+ */
+public interface IRetainScaleAndPosSetting {
+  String GUI_LINE_RETAIN_NAME = "retain_scale_pos";
+
+  boolean DEFAULT_RETAIN_SCALE_POS = false;
+  String NBT_RETAIN_SCALE_POS = "RetainScalePos";
+
+  MutableComponent txtRetain = TextUtils.translate("gui." + CreateRailwaysNavigator.MOD_ID + ".advanced_display_settings.retain_scale_pos");
+  MutableComponent txtRetainDescription = TextUtils.translate("gui." + CreateRailwaysNavigator.MOD_ID + ".advanced_display_settings.retain_scale_pos.description");
+
+  boolean shouldRetainScaleAndPos();
+  void setShouldRetainScaleAndPos(boolean v);
+
+  default void buildRetainGui(GuiBuilderContext context) {
+    GuiBuilderWrapper.buildRetainGui(this, context);
+  }
+
+  default void copyRetainSettings(IDisplaySettings oldSettings) {
+    if (oldSettings instanceof IRetainScaleAndPosSetting o) {
+      setShouldRetainScaleAndPos(o.shouldRetainScaleAndPos());
+    }
+  }
+}

--- a/common/src/main/resources/assets/createrailwaysnavigator/lang/en_us.json
+++ b/common/src/main/resources/assets/createrailwaysnavigator/lang/en_us.json
@@ -295,6 +295,8 @@
     "gui.createrailwaysnavigator.advanced_display_settings.label_background_color": "Label Background Color",
     "gui.createrailwaysnavigator.advanced_display_settings.background_color_full_size": "Full Size",
     "gui.createrailwaysnavigator.advanced_display_settings.background_color_full_size.description": "Whether the entire area of the text field should be filled or only the text.",
+    "gui.createrailwaysnavigator.advanced_display_settings.retain_scale_pos": "Retain Scale and Position",
+    "gui.createrailwaysnavigator.advanced_display_settings.retain_scale_pos.description": "Whether the scale and position should be updated by an attached display link.",
 
     "enum.createrailwaysnavigator.train_text_components": "Train Text Components",
     "enum.createrailwaysnavigator.train_text_components.description": "Text components which should be displayed on the passenger displays.",


### PR DESCRIPTION
adds an option to the rich text config screen that when enabled prevents the display link from resetting the scale and position of text to the default