### PR TITLE
new placeholders and fixes

### DIFF
--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -33,6 +33,7 @@ public class VariableManager {
     
     private static String handleStopover(@Nullable TrainStopDisplayData data, String variable) {
         boolean eta = variable.endsWith("_eta");
+        long ticksDelayed = data == null ? 0 : data.getDepartureTimeDeviation();
 
         // this should only return null if the variable is invalid so don't anyone
         // dare replace the tertiary statements with a single guard statement
@@ -42,6 +43,7 @@ public class VariableManager {
             case "platform" -> data == null ? "" : data.getRealTimeStation().info().platform();
             case "arrival", "arrival_eta" -> data == null ? "" : ModUtils.formatTime(data.getScheduledArrivalTime(), eta);
             case "departure", "departure_eta" -> data == null ? "" : ModUtils.formatTime(data.getScheduledDepartureTime(), eta);
+            case "delay_time" -> ticksDelayed <= 0 ? "" : formatDelay(ticksDelayed);
             default -> null;
         };
     }
@@ -76,7 +78,6 @@ public class VariableManager {
             case "origin" -> data == null ? "" : data.getFirstStopName();
             case "destination" -> data == null ? "" : data.getStationData().getDestination();
             case "carriages" -> data == null ? "" : "" + data.getTrainData().getCarriages();
-            case "delay_time" -> data == null ? "" : getDelayText(data);
             case "delay_reason" -> {
                 if (data == null || data.getTrainData() == null) yield "";
 
@@ -84,21 +85,6 @@ public class VariableManager {
             }
             default -> null;
         };
-    }
-
-    private static String getDelayText(StationDisplayData data) {
-        var stop = data.getStationData();
-
-        if (stop != null) {
-            long ticks = stop.getDepartureTimeDeviation();
-
-            if (ticks > 0) {
-                String formatted = formatDelay(ticks);
-                return CustomLanguage.translate("block.createrailwaysnavigator.advanced_display.ber.delayed", formatted).getString();
-            }
-        }
-
-        return "";
     }
 
     private static String formatDelay(long ticks) {

--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -69,7 +69,7 @@ public class VariableManager {
 
         if (variable.startsWith("via:")) {
             if (data == null) return "";
-            return join(data.getStopovers(), s -> s, variable.substring(4));
+            return join(data.getStopovers(), s -> s, variable.substring("via:".length()));
         }
 
         return switch (variable) {
@@ -142,7 +142,7 @@ public class VariableManager {
             if (variable.equals("via")) {
                 return join(train.getStopovers(), s -> s.getRealTimeStation().tagName(), ", ");
             } else if (variable.startsWith("via:")) {
-                return join(train.getStopovers(), s -> s.getRealTimeStation().tagName(), variable.substring(4));
+                return join(train.getStopovers(), s -> s.getRealTimeStation().tagName(), variable.substring("via:".length()));
             } else if (variable.equals("line")) {
                 return train.getTrainData().getName(ETrainStopState.beforeArrival(!train.isWaitingAtStation()));
             } else if (variable.equals("carriages")) {

--- a/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
+++ b/common/src/main/java/de/mrjulsen/crn/util/VariableManager.java
@@ -1,6 +1,7 @@
 package de.mrjulsen.crn.util;
 
 import java.util.List;
+import java.util.function.Function;
 
 import de.mrjulsen.crn.block.blockentity.AdvancedDisplayBlockEntity;
 import de.mrjulsen.crn.block.display.properties.components.ITrainStopTypeSetting;
@@ -16,6 +17,15 @@ import de.mrjulsen.mcdragonlib.util.time.TimeContext;
 import org.jetbrains.annotations.Nullable;
 
 public class VariableManager {
+    private static <T> String join(List<T> items, Function<T, String> toString, String delimiter) {
+        StringBuilder string = new StringBuilder();
+        for (int i = 0; i < items.size(); i++) {
+            if (i != 0) string.append(delimiter);
+            string.append(toString.apply(items.get(i)));
+        }
+        return string.toString();
+    }
+
     private static String handleStopover(List<TrainStopDisplayData> list, int i, String variable) {
         if (i < 0 || i >= list.size()) return handleStopover(null, variable);
         return handleStopover(list.get(i), variable);
@@ -55,8 +65,13 @@ public class VariableManager {
             return data.getStopovers().get(n);
         }
 
+        if (variable.startsWith("via:")) {
+            if (data == null) return "";
+            return join(data.getStopovers(), s -> s, variable.substring(4));
+        }
+
         return switch (variable) {
-            case "via" -> data == null ? "" : data.getStopovers().stream().reduce("", (a, b) -> a + ", " + b);
+            case "via" -> data == null ? "" : join(data.getStopovers(), s -> s, ", ");
             case "line" -> data == null ? "" : data.getTrainData().getName(ITrainStopTypeSetting.resolveStopState(data, t.showDepartures(data.isFirstStop()), t.showArrivals(data.isLastStop())));
             case "origin" -> data == null ? "" : data.getFirstStopName();
             case "destination" -> data == null ? "" : data.getStationData().getDestination();
@@ -139,11 +154,15 @@ public class VariableManager {
             TrainDisplayData train = blockEntity.getTrainData();
 
             if (variable.equals("via")) {
-                return train.getStopovers().stream().reduce("", (a, b) -> a + ", " + b.getRealTimeStation().tagName(), (a, b) -> a + ", " + b);
+                return join(train.getStopovers(), s -> s.getRealTimeStation().tagName(), ", ");
+            } else if (variable.startsWith("via:")) {
+                return join(train.getStopovers(), s -> s.getRealTimeStation().tagName(), variable.substring(4));
             } else if (variable.equals("line")) {
                 return train.getTrainData().getName(ETrainStopState.beforeArrival(!train.isWaitingAtStation()));
             } else if (variable.equals("carriages")) {
                 return "" + train.getTrainData().getCarriages();
+            } else if (variable.equals("title")) {
+                return train.getCurrentStop().map(TrainStopDisplayData::getDestination).orElse("");
             } else if (variable.startsWith("origin.")) {
                 return handleStopover(train.getAllStops(), 0, variable.substring(7));
             } else if (variable.startsWith("destination.")) {


### PR DESCRIPTION
fixes:
- remove leading comma from %via%
- remove delay approx text from %delay_time%
- move handling of %delay_time% to handleStopover so it can be used in more contexts

new placeholders:
- %via:\<custom delimiter\>% (on-board) and %trainN.via:\<custom delimiter\>% (station), sort of self explanatory
- %title% (on-board), shows the schedule title/last stop, no station version as %destination% does this already